### PR TITLE
Update for elasticsearch 0.18.7

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -16,15 +16,15 @@ This allows you to store tabular data (eg. tsv, csv) into elasticsearch.
 
 <pre><code>
 register 'target/wonderdog.jar';
-register '/usr/local/share/elasticsearch/lib/elasticsearch-0.16.0.jar';
+register '/usr/local/share/elasticsearch/lib/elasticsearch-0.18.7.jar';
 register '/usr/local/share/elasticsearch/lib/jline-0.9.94.jar';
 register '/usr/local/share/elasticsearch/lib/jna-3.2.7.jar';
-register '/usr/local/share/elasticsearch/lib/log4j-1.2.15.jar';
-register '/usr/local/share/elasticsearch/lib/lucene-analyzers-3.1.0.jar';
-register '/usr/local/share/elasticsearch/lib/lucene-core-3.1.0.jar';
-register '/usr/local/share/elasticsearch/lib/lucene-highlighter-3.1.0.jar';
-register '/usr/local/share/elasticsearch/lib/lucene-memory-3.1.0.jar';
-register '/usr/local/share/elasticsearch/lib/lucene-queries-3.1.0.jar';
+register '/usr/local/share/elasticsearch/lib/log4j-1.2.16.jar';
+register '/usr/local/share/elasticsearch/lib/lucene-analyzers-3.5.0.jar';
+register '/usr/local/share/elasticsearch/lib/lucene-core-3.5.0.jar';
+register '/usr/local/share/elasticsearch/lib/lucene-highlighter-3.5.0.jar';
+register '/usr/local/share/elasticsearch/lib/lucene-memory-3.5.0.jar';
+register '/usr/local/share/elasticsearch/lib/lucene-queries-3.5.0.jar';
 
 %default INDEX 'ufo_sightings'
 %default OBJ   'ufo_sighting'        

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>org.elasticsearch</groupId>
       <artifactId>elasticsearch</artifactId>
-      <version>0.16.0</version>
+      <version>0.18.7</version>
     </dependency>
 
     <dependency>

--- a/src/main/java/com/infochimps/elasticsearch/ElasticSearchInputFormat.java
+++ b/src/main/java/com/infochimps/elasticsearch/ElasticSearchInputFormat.java
@@ -27,8 +27,8 @@ import org.elasticsearch.client.Requests;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.search.SearchType;
-import org.elasticsearch.index.query.xcontent.FilterBuilders.*;
-import org.elasticsearch.index.query.xcontent.QueryBuilders;
+import org.elasticsearch.index.query.FilterBuilders.*;
+import org.elasticsearch.index.query.QueryBuilders;
 
 /**
    


### PR DESCRIPTION
In elasticsearch 0.17, there was a refactoring of the querybuilders, breaking wonderdog. Switching around the imports should fix it.
