### PR TITLE
Fixes Wonderdog Pig 0.10 compatability issues and issues 5, 6, 7 and PIG-2792

### DIFF
--- a/src/main/java/com/infochimps/elasticsearch/ElasticSearchOutputFormat.java
+++ b/src/main/java/com/infochimps/elasticsearch/ElasticSearchOutputFormat.java
@@ -120,7 +120,8 @@ public class ElasticSearchOutputFormat extends OutputFormat<NullWritable, MapWri
             this.objType    = conf.get(ES_OBJECT_TYPE);
             
             //
-            // Fetches elasticsearch.yml and the plugins directory from the distributed cache
+            // Fetches elasticsearch.yml and the plugins directory from the distributed cache, or
+            // from the local config.
             //
             try {
                 String taskConfigPath = HadoopUtils.fetchFileFromCache(ES_CONFIG_NAME, conf);
@@ -130,7 +131,8 @@ public class ElasticSearchOutputFormat extends OutputFormat<NullWritable, MapWri
                 System.setProperty(ES_CONFIG, taskConfigPath);
                 System.setProperty(ES_PLUGINS, taskPluginsPath+SLASH+ES_PLUGINS_NAME);
             } catch (Exception e) {
-                throw new RuntimeException(e);
+                System.setProperty(ES_CONFIG,conf.get(ES_CONFIG));
+                System.setProperty(ES_PLUGINS,conf.get(ES_PLUGINS));
             }
             
             start_embedded_client();


### PR DESCRIPTION
Fixed Wonderdog for Pig 0.10 and Pig local mode by checking the conf object if the call to the hadoop cache misses
